### PR TITLE
Add CGAL 2D

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Benoît Legat <benoit.legat@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+CGAL = "15fcbb24-5a00-427b-98c5-e32879a22884"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MiniQhull = "978d7f02-9e05-4691-894f-ae31a51d76ca"
 Polyhedra = "67491407-f73d-577b-9b50-8179a7c68029"
@@ -11,6 +12,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 VoronoiDelaunay = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
 
 [compat]
+CGAL = "0.5"
 MiniQhull = "0.3"
 Polyhedra = "0.7"
 StaticArrays = "1"

--- a/src/HyperVoronoiDelaunay.jl
+++ b/src/HyperVoronoiDelaunay.jl
@@ -96,9 +96,17 @@ function delaunay(points::Vector{SVector{N,T}}, algo::typeof(MiniQhull.delaunay)
 end
 
 import CGAL
-function delaunay(points::Vector{SVector{N,T}}, algo::Type{<:CGAL.Triangulation}, ::NonPeriodic) where {N,T}
-    insert(CGAL.Triangulation(), CGAL.Point.(points))
-    simplices = Matrix{Int}(undef, N+1, length(Δs))
+function delaunay(points::Vector{SVector{N,T}}, algo::Type{CGAL.DelaunayTriangulation2}, ::NonPeriodic) where {N,T}
+    cgal_points = [CGAL.Point2(point...) for point in points]
+    index = Dict(point => index for (index, point) in enumerate(cgal_points))
+    t = CGAL.DelaunayTriangulation2(cgal_points)
+    fs = CGAL.faces(t)
+    simplices = Matrix{Int}(undef, N+1, length(fs))
+    for (i, f) in enumerate(fs)
+        for j in 1:(N+1)
+            simplices[i, j] = index[CGAL.point(CGAL.vertex(f, j))]
+        end
+    end
     return simplices
 end
 

--- a/src/HyperVoronoiDelaunay.jl
+++ b/src/HyperVoronoiDelaunay.jl
@@ -95,6 +95,13 @@ function delaunay(points::Vector{SVector{N,T}}, algo::typeof(MiniQhull.delaunay)
     return MiniQhull.delaunay(points)
 end
 
+import CGAL
+function delaunay(points::Vector{SVector{N,T}}, algo::Type{<:CGAL.Triangulation}, ::NonPeriodic) where {N,T}
+    insert(CGAL.Triangulation(), CGAL.Point.(points))
+    simplices = Matrix{Int}(undef, N+1, length(Δs))
+    return simplices
+end
+
 function shift_point(point::SVector{N,T}, shift::NTuple{N,Int}, period::SVector{N,T}) where {N,T}
     return point .+ shift .* period
 end

--- a/src/HyperVoronoiDelaunay.jl
+++ b/src/HyperVoronoiDelaunay.jl
@@ -99,13 +99,15 @@ import CGAL
 function delaunay(points::Vector{SVector{N,T}}, algo::Type{CGAL.DelaunayTriangulation2}, ::NonPeriodic) where {N,T}
     cgal_points = [CGAL.Point2(point...) for point in points]
     # FIXME is there an easier way to get the index and not the coordinate from CGAL ?
-    index = Dict(point => index for (index, point) in enumerate(cgal_points))
+    index = Dict(point => index for (index, point) in enumerate(points))
     t = CGAL.DelaunayTriangulation2(cgal_points)
     fs = CGAL.faces(t)
     simplices = Matrix{Int}(undef, N+1, length(fs))
     for (i, f) in enumerate(fs)
         for j in 1:(N+1)
-            simplices[i, j] = index[CGAL.point(CGAL.vertex(f, j))]
+            cgal_v = CGAL.point(CGAL.vertex(f, j))
+            v = SVector{N,T}(CGAL.x(cgal_v), CGAL.y(cgal_v))
+            simplices[j, i] = index[v]
         end
     end
     return simplices

--- a/src/HyperVoronoiDelaunay.jl
+++ b/src/HyperVoronoiDelaunay.jl
@@ -98,6 +98,7 @@ end
 import CGAL
 function delaunay(points::Vector{SVector{N,T}}, algo::Type{CGAL.DelaunayTriangulation2}, ::NonPeriodic) where {N,T}
     cgal_points = [CGAL.Point2(point...) for point in points]
+    # FIXME is there an easier way to get the index and not the coordinate from CGAL ?
     index = Dict(point => index for (index, point) in enumerate(cgal_points))
     t = CGAL.DelaunayTriangulation2(cgal_points)
     fs = CGAL.faces(t)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 CGAL = "15fcbb24-5a00-427b-98c5-e32879a22884"
+HyperVoronoiDelaunay = "1a55de6a-d783-4007-8775-0d59a3e033cc"
 MiniQhull = "978d7f02-9e05-4691-894f-ae31a51d76ca"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 QHull = "a8468747-bd6f-53ef-9e5c-744dbc5c59e7"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
+CGAL = "15fcbb24-5a00-427b-98c5-e32879a22884"
 MiniQhull = "978d7f02-9e05-4691-894f-ae31a51d76ca"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 QHull = "a8468747-bd6f-53ef-9e5c-744dbc5c59e7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ end
 
 function test_grid_0(lib)
     simplices = _test_grid(0, lib)
-    @show size(simplices)
+    @test size(simplices) == (3, 0)
 end
 
 function test_grid_1(lib)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ import CDDLib
 import QHull
 import VoronoiDelaunay
 import MiniQhull
+import CGAL
 
 using HyperVoronoiDelaunay
 
@@ -65,7 +66,7 @@ function test_periodic(algo)
     @test hascol(d, [[10, 13, 14], [13, 16, 17]])
 end
 
-LIBRARIES = [MiniQhull.delaunay, QHull.Library(), CDDLib.Library(:float), VoronoiDelaunay.DelaunayTessellation2D]
+LIBRARIES = [MiniQhull.delaunay, QHull.Library(), CDDLib.Library(:float), VoronoiDelaunay.DelaunayTessellation2D, CGAL.DelaunayTriangulation2]
 
 @testset "Test issue 55 $lib" for lib in LIBRARIES
     if lib != VoronoiDelaunay.DelaunayTessellation2D


### PR DESCRIPTION
CGAL supports [2D triangulation](https://doc.cgal.org/latest/Triangulation_2/index.html), [3D triangulation](https://doc.cgal.org/latest/Triangulation_3/index.html) as well as [dD triangulation](https://doc.cgal.org/latest/Triangulation/index.html). This PR adds support for using the 2D version through the interface of this packages thanks to the Julia interface of CGAL.jl